### PR TITLE
Adds Action (Endo a) instance

### DIFF
--- a/src/Data/Monoid/Action.hs
+++ b/src/Data/Monoid/Action.hs
@@ -68,3 +68,8 @@ instance Action () l where
 instance Action m s => Action (Option m) s where
   act (Option Nothing)  s = s
   act (Option (Just m)) s = act m s
+
+-- | @Endo@ acts by application.
+instance Action (Endo a) a where
+    act = appEndo
+


### PR DESCRIPTION
Adds an action instance for endomorphisms (from `Data.Monoid`).
