### PR TITLE
Expose Pos and Neg definitions

### DIFF
--- a/src/Data/Monoid/Inf.hs
+++ b/src/Data/Monoid/Inf.hs
@@ -20,6 +20,7 @@
 
 module Data.Monoid.Inf
        ( Inf(..)
+       , Pos, Neg
        , PosInf, NegInf
        , minimum, maximum
        -- * Type-restricted constructors


### PR DESCRIPTION
We want instances such as (Monoid (Inf Neg a)) to show up in the docs,
but this doesn't happen if Pos and Neg are not visible. The noise is
worth it as it makes the purpose of Inf more clear.
