### PR TITLE
add derived Show instances for all types

### DIFF
--- a/src/Data/Monoid/Coproduct.hs
+++ b/src/Data/Monoid/Coproduct.hs
@@ -34,6 +34,7 @@ import Data.Monoid.Action
 --   concatenation, with appropriate combining of adjacent elements
 --   when possible.
 newtype m :+: n = MCo { unMCo :: [Either m n] }
+                  deriving Show
 
 -- For efficiency and simplicity, we implement it just as [Either m
 -- n]: of course, this does not preserve the invariant of strictly

--- a/src/Data/Monoid/Deletable.hs
+++ b/src/Data/Monoid/Deletable.hs
@@ -52,7 +52,7 @@ import Data.Semigroup
 --   * The remaining case is symmetric with the second.
 
 data Deletable m = Deletable Int m Int
-  deriving Functor
+  deriving (Functor, Show)
 
 -- | Project the wrapped value out of a `Deletable` value.
 unDelete :: Deletable m -> m

--- a/src/Data/Monoid/Endomorphism.hs
+++ b/src/Data/Monoid/Endomorphism.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Monoid.Endomorphism
@@ -19,13 +22,15 @@ import           Data.Group
 import           Data.Groupoid
 import           Data.Semigroup
 import           Data.Semigroupoid
-import           Prelude           ()
+import           Prelude           (Show)
 
 -- | An 'Endomorphism' in a given 'Category' is a morphism from some
 --   object to itself.  The set of endomorphisms for a particular
 --   object form a monoid, with composition as the combining operation
 --   and the identity morphism as the identity element.
 newtype Endomorphism k a = Endomorphism {getEndomorphism :: k a a}
+
+deriving instance Show (k a a) =>  Show (Endomorphism k a)
 
 instance Semigroupoid k => Semigroup (Endomorphism k a) where
   Endomorphism a <> Endomorphism b = Endomorphism (a `o` b)

--- a/src/Data/Monoid/MList.hs
+++ b/src/Data/Monoid/MList.hs
@@ -114,6 +114,7 @@ instance (t :>: a) => (:>:) (b ::: t) a where
 --   guide instance selection when defining the action of
 --   heterogeneous monoidal lists on each other.
 newtype SM m = SM m
+               deriving Show
 
 instance (Action (SM a) l2, Action l1 l2) => Action (a, l1) l2 where
   act (a,l) = act (SM a) . act l

--- a/src/Data/Monoid/Recommend.hs
+++ b/src/Data/Monoid/Recommend.hs
@@ -1,4 +1,3 @@
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Monoid.Recommend
@@ -29,6 +28,7 @@ import Data.Semigroup
 --   overriding any @Recommend@ed values.
 data Recommend a = Recommend a
                  | Commit a
+                   deriving Show
 
 -- | Extract the value of type @a@ wrapped in @Recommend a@.
 getRecommend :: Recommend a -> a


### PR DESCRIPTION
closes #6 

Several language extensions were required to provide the instance for `Endomorphism`.  Is this a problem?
