### PR TITLE
update for GHC-7.10, -Wall

### DIFF
--- a/src/Data/Monoid/Cut.hs
+++ b/src/Data/Monoid/Cut.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE DeriveFoldable     #-}
 {-# LANGUAGE DeriveFunctor      #-}
 {-# LANGUAGE DeriveTraversable  #-}
-
+{-# OPTIONS_GHC -fno-warn-unused-imports       #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Monoid.Cut

--- a/src/Data/Monoid/Deletable.hs
+++ b/src/Data/Monoid/Deletable.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE DeriveFoldable     #-}
 {-# LANGUAGE DeriveFunctor      #-}
 {-# LANGUAGE DeriveTraversable  #-}
-
+{-# OPTIONS_GHC -fno-warn-unused-imports       #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Monoid.Deletable

--- a/src/Data/Monoid/Inf.hs
+++ b/src/Data/Monoid/Inf.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE DeriveTraversable  #-}
 {-# LANGUAGE EmptyDataDecls     #-}
 {-# LANGUAGE FlexibleInstances  #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports       #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Monoid.Inf

--- a/src/Data/Monoid/MList.hs
+++ b/src/Data/Monoid/MList.hs
@@ -1,12 +1,15 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE OverlappingInstances       #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE TypeSynonymInstances       #-}
 {-# LANGUAGE UndecidableInstances       #-}
+#if __GLASGOW_HASKELL__ < 710
+{-# LANGUAGE OverlappingInstances       #-}
+#endif
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -91,7 +94,11 @@ class l :>: a where
   -- | Alter the value of type @a@ by applying the given function to it.
   alt  :: (Option a -> Option a) -> l -> l
 
+#if __GLASGOW_HASKELL__ >= 710
+instance {-# OVERLAPPING #-} MList t => (:>:) (a ::: t) a where
+#else
 instance MList t => (:>:) (a ::: t) a where
+#endif
   inj a = (Option (Just a), empty)
   get   = fst
   alt   = first

--- a/src/Data/Monoid/Split.hs
+++ b/src/Data/Monoid/Split.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE DeriveTraversable     #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-
+{-# OPTIONS_GHC -fno-warn-unused-imports       #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Monoid.Split


### PR DESCRIPTION
Most of Foldable & Traversable are now in Prelude, so importing these
libraries is redundant.  To support older GHC as well, I've just
disabled those warnings.  There are a couple of other options:

- CPP to conditionally import
- import Prelude explicitly after Foldable, Traversable

The change to Overlapping Instances may improve instance resolution in
some cases, so I've opted for CPP to use the new pragmas if available.
With this one pragma, the diagrams-core branch that I'm about to push
builds.  I haven't yet checked if other instances overlap.