### PR TITLE
the semi-direct product of two monoids.

### DIFF
--- a/monoid-extras.cabal
+++ b/monoid-extras.cabal
@@ -22,6 +22,7 @@ source-repository head
 library
   default-language:  Haskell2010
   exposed-modules:   Data.Monoid.Action,
+                     Data.Monoid.SemiDirectProduct,
                      Data.Monoid.Coproduct,
                      Data.Monoid.Cut,
                      Data.Monoid.Deletable,

--- a/src/Data/Monoid/SemiDirectProduct.hs
+++ b/src/Data/Monoid/SemiDirectProduct.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TupleSections         #-}
+
+module Data.Monoid.SemiDirectProduct
+       ( Semi, quotient, inject, embed
+       ) where
+
+import Data.Monoid
+import Data.Monoid.Action
+
+-- | The semi-direct product of monoids @s@ and @m@. When the monoid
+-- @m@ acts on the monoid @s@, this type acquires a monoid structure.
+-- We call the monoid @m@ the quotient monoid and the monoid @s@ the
+-- sub-monoid of the semi-direct product. The semi-direct product
+-- @Semi s m@ is an extension of the monoid @s@ with @m@ being the
+-- quotient.
+newtype Semi s m = Semi { unSemi :: (s,m) }
+
+
+instance (Monoid m, Monoid s, Action m s) => Monoid (Semi s m) where
+  mempty      = Semi (mempty, mempty)
+  mappend x y = Semi (xs `mappend` (xm `act` ys), xm `mappend` ym)
+    where (xs, xm) = unSemi x
+          (ys, ym) = unSemi y
+
+
+-- | The quotient map.
+quotient :: Semi s m -> m
+quotient = snd . unSemi
+
+-- | The injection map.
+inject :: Monoid m => s -> Semi s m
+inject = Semi . (,mempty)
+
+-- | The semi-direct product gives a split extension of @s@ by
+-- @m@. This allows us to embed @m@ into the semi-direct product. This
+-- is the embedding map. The quotient and embed maps should satisfy
+-- the equation @quotient . embed = id@.
+embed :: Monoid s => m -> Semi s m
+embed = Semi . (mempty,)

--- a/src/Data/Monoid/SemiDirectProduct.hs
+++ b/src/Data/Monoid/SemiDirectProduct.hs
@@ -1,12 +1,16 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE CPP                   #-}
 
 module Data.Monoid.SemiDirectProduct
        ( Semi, quotient, inject, embed
        ) where
 
+#if !MIN_VERSION_base(4,8,0)
 import Data.Monoid
+#endif
+
 import Data.Monoid.Action
 
 -- | The semi-direct product of monoids @s@ and @m@. When the monoid


### PR DESCRIPTION
This commit has the implementation of the semi-direct products. As discussed (in private correspondence with @byorgey) this construction can replace some use of the untangle operation. There is a question
of the correct strictness though. We might want a strict version of this product as well for performance.  