### PR TITLE
added monoid action on functional spaces.

### DIFF
--- a/monoid-extras.cabal
+++ b/monoid-extras.cabal
@@ -23,6 +23,7 @@ library
   default-language:  Haskell2010
   exposed-modules:   Data.Monoid.Action,
                      Data.Monoid.SemiDirectProduct,
+                     Data.Monoid.SemiDirectProduct.Strict
                      Data.Monoid.Coproduct,
                      Data.Monoid.Cut,
                      Data.Monoid.Deletable,

--- a/src/Data/Monoid/Action.hs
+++ b/src/Data/Monoid/Action.hs
@@ -81,3 +81,9 @@ instance Action m s => Action (Option m) s where
 instance Action (Endo a) a where
   act = appEndo
 
+-- | Action of a monoid @m@ on a set @s@ can be lifted to the
+-- functional space s -> a.  Recall that the type s -> a is a monoid
+-- for any monoid a. The lifted action is indeed a valid monoid action
+-- for a fixed a irrespective of whether s is a monoid or not.
+instance Action m s => Action m (s -> a) where
+  act m f s =  f $ m `act` s

--- a/src/Data/Monoid/SemiDirectProduct/Strict.hs
+++ b/src/Data/Monoid/SemiDirectProduct/Strict.hs
@@ -1,0 +1,46 @@
+-- | A strict version of the semi-direct product. If a monoid m acts
+-- on s then this version of the semi-direct product is strict in the
+-- m-portion of the semi-direct product.
+
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE CPP                   #-}
+
+module Data.Monoid.SemiDirectProduct.Strict
+       ( Semi, quotient, inject, embed
+       ) where
+
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid
+#endif
+
+import Data.Monoid.Action
+
+-- | The semi-direct product of monoids @s@ and @m@. When the monoid
+-- @m@ acts on the monoid @s@, this type acquires a monoid structure.
+-- We call the monoid @m@ the quotient monoid and the monoid @s@ the
+-- sub-monoid of the semi-direct product. The semi-direct product
+-- @Semi s m@ is an extension of the monoid @s@ with @m@ being the
+-- quotient.
+data Semi s m = Semi s !m
+
+
+instance (Monoid m, Monoid s, Action m s) => Monoid (Semi s m) where
+  mempty                            = Semi mempty mempty
+  mappend (Semi xs xm) (Semi ys ym) = Semi (xs `mappend` (xm `act` ys)) (xm `mappend` ym)
+
+-- | The quotient map.
+quotient :: Semi s m -> m
+quotient (Semi s m) = m
+
+-- | The injection map.
+inject :: Monoid m => s -> Semi s m
+inject = flip Semi mempty
+
+-- | The semi-direct product gives a split extension of @s@ by
+-- @m@. This allows us to embed @m@ into the semi-direct product. This
+-- is the embedding map. The quotient and embed maps should satisfy
+-- the equation @quotient . embed = id@.
+embed :: Monoid s => m -> Semi s m
+embed = Semi mempty


### PR DESCRIPTION
Let s be any type and let m act on it. Then one can lift the action of the monoid m to the functional space
`s -> a` for any type `a`. This is essentially the point wise multiplication.  If in addition a is a monoid, then
`s -> a` is a monoid  and lifted action is nice in the sense that it satisfies the additional laws required for monoid action on monoids. I guess therefore this instance is a natural addition.