### PR TITLE
some optimisations for strict semi-direct products

### DIFF
--- a/benchmarks/SemiDirectProduct.hs
+++ b/benchmarks/SemiDirectProduct.hs
@@ -10,7 +10,7 @@ import           Criterion.Main
 #if !MIN_VERSION_base(4,8,0)
 import           Data.Monoid
 #else
-import           Data.Monoid (Sum)
+import           Data.Monoid (Sum(..))
 #endif
 
 import           Data.Word

--- a/benchmarks/SemiDirectProduct.hs
+++ b/benchmarks/SemiDirectProduct.hs
@@ -8,10 +8,12 @@ module Main where
 import           Criterion.Main
 
 #if !MIN_VERSION_base(4,8,0)
-import Data.Monoid
+import           Data.Monoid
+#else
+import           Data.Monoid (Sum)
 #endif
 
-import Data.Word
+import           Data.Word
 
 import           Data.Monoid.Action
 import qualified Data.Monoid.SemiDirectProduct        as L
@@ -19,7 +21,7 @@ import qualified Data.Monoid.SemiDirectProduct.Strict as S
 
 newtype MyMonoid = MyMonoid (Sum Word) deriving Monoid
 
-instance Action (MyMonoid) () where
+instance Action MyMonoid () where
   act _ = id
   {-# NOINLINE act #-}
 

--- a/benchmarks/SemiDirectProduct.hs
+++ b/benchmarks/SemiDirectProduct.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Main where
+
+import           Control.Monad
+import           Criterion.Main
+
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid
+#endif
+
+import Data.Word
+
+import           Data.Monoid.Action
+import qualified Data.Monoid.SemiDirectProduct        as L
+import qualified Data.Monoid.SemiDirectProduct.Strict as S
+
+instance Action (Sum Word) () where
+  act _ = id
+  {-# NOINLINE act #-}
+
+main :: IO ()
+main = defaultMain
+       [ bench "mconcat/strict"   $ whnf mconcat strict
+       , bench "mconcat/lazy"     $ whnf mconcat lazy
+       , bench "strict/quotient"  $ whnf (S.quotient . mconcat) strict
+       , bench "lazy/quotient"    $ whnf (L.quotient . mconcat) lazy
+       ]
+  where strict :: [S.Semi () (Sum Word)]
+        strict =  map (S.embed . Sum) $ take 1000 [1..]
+        lazy   :: [L.Semi () (Sum Word)]
+        lazy   =  map (L.embed . Sum) $ take 1000 [1..]

--- a/benchmarks/SemiDirectProduct.hs
+++ b/benchmarks/SemiDirectProduct.hs
@@ -4,7 +4,6 @@
 
 module Main where
 
-import           Control.Monad
 import           Criterion.Main
 
 #if !MIN_VERSION_base(4,8,0)

--- a/benchmarks/SemiDirectProduct.hs
+++ b/benchmarks/SemiDirectProduct.hs
@@ -9,11 +9,10 @@ import           Criterion.Main
 
 #if !MIN_VERSION_base(4,8,0)
 import           Data.Monoid
+import           Data.Word
 #else
 import           Data.Monoid (Sum(..))
 #endif
-
-import           Data.Word
 
 import           Data.Monoid.Action
 import qualified Data.Monoid.SemiDirectProduct        as L

--- a/benchmarks/SemiDirectProduct.hs
+++ b/benchmarks/SemiDirectProduct.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE CPP                   #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Main where
 
@@ -16,7 +17,9 @@ import           Data.Monoid.Action
 import qualified Data.Monoid.SemiDirectProduct        as L
 import qualified Data.Monoid.SemiDirectProduct.Strict as S
 
-instance Action (Sum Word) () where
+newtype MyMonoid = MyMonoid (Sum Word) deriving Monoid
+
+instance Action (MyMonoid) () where
   act _ = id
   {-# NOINLINE act #-}
 
@@ -27,7 +30,7 @@ main = defaultMain
        , bench "strict/quotient"  $ whnf (S.quotient . mconcat) strict
        , bench "lazy/quotient"    $ whnf (L.quotient . mconcat) lazy
        ]
-  where strict :: [S.Semi () (Sum Word)]
-        strict =  map (S.embed . Sum) $ take 1000 [1..]
-        lazy   :: [L.Semi () (Sum Word)]
-        lazy   =  map (L.embed . Sum) $ take 1000 [1..]
+  where strict :: [S.Semi () MyMonoid]
+        strict =  map (S.embed . MyMonoid . Sum) $ take 1000 [1..]
+        lazy   :: [L.Semi () (MyMonoid)]
+        lazy   =  map (L.embed . MyMonoid . Sum) $ take 1000 [1..]

--- a/monoid-extras.cabal
+++ b/monoid-extras.cabal
@@ -51,6 +51,6 @@ benchmark semi-direct-product
   hs-source-dirs: benchmarks
   main-is: SemiDirectProduct.hs
   type: exitcode-stdio-1.0
-  build-depends: base
+  build-depends: base          >= 4.3 &&  < 4.10
                , criterion
                , monoid-extras == 0.4.0.2

--- a/monoid-extras.cabal
+++ b/monoid-extras.cabal
@@ -45,3 +45,12 @@ library
                      FlexibleInstances,
                      MultiParamTypeClasses,
                      TypeOperators
+
+benchmark semi-direct-product
+  default-language:  Haskell2010
+  hs-source-dirs: benchmarks
+  main-is: SemiDirectProduct.hs
+  type: exitcode-stdio-1.0
+  build-depends: base
+               , criterion
+               , monoid-extras == 0.4.0.2

--- a/src/Data/Monoid/SemiDirectProduct.hs
+++ b/src/Data/Monoid/SemiDirectProduct.hs
@@ -24,10 +24,15 @@ newtype Semi s m = Semi { unSemi :: (s,m) }
 
 instance (Monoid m, Monoid s, Action m s) => Monoid (Semi s m) where
   mempty      = Semi (mempty, mempty)
+  {-# INLINE mempty #-}
+
   mappend x y = Semi (xs `mappend` (xm `act` ys), xm `mappend` ym)
     where (xs, xm) = unSemi x
           (ys, ym) = unSemi y
 
+  {-# INLINE mappend #-}
+  mconcat     = foldr mappend mempty
+  {-# INLINE mconcat #-}
 
 -- | The quotient map.
 quotient :: Semi s m -> m

--- a/src/Data/Monoid/SemiDirectProduct/Strict.hs
+++ b/src/Data/Monoid/SemiDirectProduct/Strict.hs
@@ -28,8 +28,12 @@ data Semi s m = Semi s !m
 
 instance (Monoid m, Monoid s, Action m s) => Monoid (Semi s m) where
   mempty                            = Semi mempty mempty
+  {-# INLINE mempty #-}
   mappend (Semi xs xm) (Semi ys ym) = Semi (xs `mappend` (xm `act` ys)) (xm `mappend` ym)
-
+  {-# INLINE mappend #-}
+  mconcat                           = foldr mappend mempty
+  {-# INLINE mconcat #-}
+  
 -- | The quotient map.
 quotient :: Semi s m -> m
 quotient (Semi _ m) = m


### PR DESCRIPTION
- Added some inlining
- Added a definition for mconcat instead of relying on the default.

These are know to improve performace dramatically (10x). Benchmarks in raaz seems to convey that.
The particular settings I copied from the Monoid instance of Write in Blaze-builder.

