### PR TITLE
Add `Action` instance given an instance for `Functor`

### DIFF
--- a/src/Data/Monoid/Action.hs
+++ b/src/Data/Monoid/Action.hs
@@ -81,3 +81,6 @@ instance Action m s => Action (Option m) s where
 instance Action (Endo a) a where
   act = appEndo
 
+-- | Use @fmap@ to apply @act@.
+instance (Functor f, Action m a) => Action m (f a) where
+  act m = fmap (act m)


### PR DESCRIPTION
Adds a new instance for `Action`, given a `Functor` constraint, as mentioned in the paper "Monoids: Theme and Variations".

I am not sure if this instance was left out with purpose due to the comment:

> In practice, this library has chosen to have instance selection for `Action` driven by the *first* type parameter.

or if it was simply forgotten, so taking some chances here ;)