### PR TITLE
Bump base bound for GHC 8.2

### DIFF
--- a/monoid-extras.cabal
+++ b/monoid-extras.cabal
@@ -35,7 +35,7 @@ library
                      Data.Monoid.Split,
                      Data.Monoid.WithSemigroup
 
-  build-depends:     base >= 4.3 && < 4.10,
+  build-depends:     base >= 4.3 && < 4.11,
                      groups < 0.5,
                      semigroups >= 0.8 && < 0.19,
                      semigroupoids >= 4.0 && < 5.3
@@ -52,6 +52,6 @@ benchmark semi-direct-product
   hs-source-dirs: benchmarks
   main-is: SemiDirectProduct.hs
   type: exitcode-stdio-1.0
-  build-depends: base          >= 4.3 &&  < 4.10
+  build-depends: base          >= 4.3 &&  < 4.11
                , criterion
                , monoid-extras


### PR DESCRIPTION
GHC 8.2 ships with base-4.10.
The package still builds after this change.