### PR TITLE
Fix the build with GHC 8.4

### DIFF
--- a/benchmarks/SemiDirectProduct.hs
+++ b/benchmarks/SemiDirectProduct.hs
@@ -13,12 +13,15 @@ import           Data.Word
 #else
 import           Data.Monoid (Sum(..))
 #endif
+#if !MIN_VERSION_base(4,11,0)
+import           Data.Semigroup (Semigroup)
+#endif
 
 import           Data.Monoid.Action
 import qualified Data.Monoid.SemiDirectProduct        as L
 import qualified Data.Monoid.SemiDirectProduct.Strict as S
 
-newtype MyMonoid = MyMonoid (Sum Word) deriving Monoid
+newtype MyMonoid = MyMonoid (Sum Word) deriving (Semigroup, Monoid)
 
 instance Action MyMonoid () where
   act _ = id

--- a/src/Data/Monoid/Endomorphism.hs
+++ b/src/Data/Monoid/Endomorphism.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -20,7 +21,8 @@ module Data.Monoid.Endomorphism
 import           Control.Category
 import           Data.Group
 import           Data.Groupoid
-import           Data.Semigroup
+import           Data.Monoid       (Monoid(..))
+import           Data.Semigroup    (Semigroup(..))
 import           Data.Semigroupoid
 import           Prelude           (Show)
 
@@ -35,9 +37,11 @@ deriving instance Show (k a a) => Show (Endomorphism k a)
 instance Semigroupoid k => Semigroup (Endomorphism k a) where
   Endomorphism a <> Endomorphism b = Endomorphism (a `o` b)
 
-instance Category k => Monoid (Endomorphism k a) where
+instance (Semigroupoid k, Category k) => Monoid (Endomorphism k a) where
   mempty = Endomorphism id
+#if !MIN_VERSION_base(4,11,0)
   Endomorphism a `mappend` Endomorphism b = Endomorphism (a . b)
+#endif
 
 instance (Category k, Groupoid k) => Group (Endomorphism k a) where
   invert (Endomorphism a) = Endomorphism (inv a)

--- a/src/Data/Monoid/SemiDirectProduct.hs
+++ b/src/Data/Monoid/SemiDirectProduct.hs
@@ -8,8 +8,9 @@ module Data.Monoid.SemiDirectProduct
        ) where
 
 #if !MIN_VERSION_base(4,8,0)
-import           Data.Monoid
+import           Data.Monoid        (Monoid(..))
 #endif
+import           Data.Semigroup     (Semigroup(..))
 
 import           Data.Monoid.Action
 
@@ -29,16 +30,27 @@ import           Data.Monoid.Action
 --   quotient.
 newtype Semi s m = Semi { unSemi :: (s,m) }
 
+instance (Semigroup m, Semigroup s, Action m s) => Semigroup (Semi s m) where
+  x <> y = Semi (xs <> (xm `act` ys), xm <> ym)
+    where (xs, xm) = unSemi x
+          (ys, ym) = unSemi y
+  {-# INLINE (<>) #-}
+
+  sconcat = foldr1 (<>)
+  {-# INLINE sconcat #-}
 
 instance (Monoid m, Monoid s, Action m s) => Monoid (Semi s m) where
   mempty      = Semi (mempty, mempty)
   {-# INLINE mempty #-}
 
+#if !MIN_VERSION_base(4,11,0)
   mappend x y = Semi (xs `mappend` (xm `act` ys), xm `mappend` ym)
     where (xs, xm) = unSemi x
           (ys, ym) = unSemi y
 
   {-# INLINE mappend #-}
+#endif
+
   mconcat     = foldr mappend mempty
   {-# INLINE mconcat #-}
 

--- a/src/Data/Monoid/SemiDirectProduct/Strict.hs
+++ b/src/Data/Monoid/SemiDirectProduct/Strict.hs
@@ -12,8 +12,9 @@ module Data.Monoid.SemiDirectProduct.Strict
        ) where
 
 #if !MIN_VERSION_base(4,8,0)
-import           Data.Monoid
+import           Data.Monoid        (Monoid(..))
 #endif
+import           Data.Semigroup     (Semigroup(..))
 
 import           Data.Monoid.Action
 
@@ -33,11 +34,19 @@ data Semi s m = Semi s !m
 unSemi :: Semi s m -> (s,m)
 unSemi (Semi s m) = (s,m)
 
+instance (Semigroup m, Semigroup s, Action m s) => Semigroup (Semi s m) where
+  Semi xs xm <> Semi ys ym          = Semi (xs <> (xm `act` ys)) (xm <> ym)
+  {-# INLINE (<>) #-}
+  sconcat                           = foldr1 (<>)
+  {-# INLINE sconcat #-}
+
 instance (Monoid m, Monoid s, Action m s) => Monoid (Semi s m) where
   mempty                            = Semi mempty mempty
   {-# INLINE mempty #-}
+#if !MIN_VERSION_base(4,11,0)
   mappend (Semi xs xm) (Semi ys ym) = Semi (xs `mappend` (xm `act` ys)) (xm `mappend` ym)
   {-# INLINE mappend #-}
+#endif
   mconcat                           = foldr mappend mempty
   {-# INLINE mconcat #-}
 


### PR DESCRIPTION
`Semigroup` is now a superclass of `Monoid` in GHC 8.4, and several parts of `monoid-extras` need to be updated accordingly.