### PR TITLE
Fix build for older GHCs

### DIFF
--- a/monoid-extras.cabal
+++ b/monoid-extras.cabal
@@ -36,7 +36,7 @@ library
                      Data.Monoid.Split,
                      Data.Monoid.WithSemigroup
 
-  build-depends:     base >= 4.3 && < 4.14,
+  build-depends:     base >= 4.5 && < 4.14,
                      groups < 0.5,
                      semigroups >= 0.8 && < 0.20,
                      semigroupoids >= 4.0 && < 5.4
@@ -45,10 +45,11 @@ library
 
   ghc-options: -Wall
 
-  other-extensions:  DeriveFunctor,
-                     FlexibleInstances,
-                     MultiParamTypeClasses,
+  other-extensions:  DeriveFunctor
+                     FlexibleInstances
+                     MultiParamTypeClasses
                      TypeOperators
+                     ConstraintKinds
 
 benchmark semi-direct-product
   default-language:  Haskell2010

--- a/src/Data/Monoid/Coproduct/Strict.hs
+++ b/src/Data/Monoid/Coproduct/Strict.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MonoLocalBinds        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE TypeOperators         #-}
+
+-- For GHC-7.4
+{-# LANGUAGE UndecidableInstances  #-}
 
 -----------------------------------------------------------------------------
 -- |


### PR DESCRIPTION
- Older GHCs require `ConstraintKinds` to be enable also in the
  used module (upto GHC-7.8.4).
- GHC-7.4.2 requires `UndecidableInstances`, let it have it
- Add `ConstraintKinds` to `other-extensions`
- And also indicate in `base >= 4.5` that 7.4 is the older GHC
  one can have (though that's indicated by `ConstraintKinds` already).

---

I made revisions, so released versions have similar changes: https://matrix.hackage.haskell.org/#/package/monoid-extras

I'm not sure if the release is needed for `diagrams` reverse dependencies to work with `GHC-7.8`.