### PR TITLE
added stimes implementations

### DIFF
--- a/src/Data/Monoid/Cut.hs
+++ b/src/Data/Monoid/Cut.hs
@@ -61,6 +61,9 @@ instance Semigroup m => Semigroup (Cut m) where
   (m1  :||: m2) <> (Uncut m2')   = m1        :||: m2 <> m2'
   (m11 :||: _)  <> (_ :||: m22)  = m11       :||: m22
 
+  stimes n (Uncut m) = Uncut (stimes n m)
+  stimes n (m      ) = m
+
 instance (Semigroup m, Monoid m) => Monoid (Cut m) where
   mempty  = Uncut mempty
   mappend = (<>)

--- a/src/Data/Monoid/Deletable.hs
+++ b/src/Data/Monoid/Deletable.hs
@@ -77,6 +77,13 @@ instance Semigroup m => Semigroup (Deletable m) where
     | l1 <  r2  = Deletable (r1 + r2 - l1) m2 l2
     | otherwise = Deletable r1 m1 (l2 + l1 - r2)
 
+  stimes n (Deletable r m l)
+    | r == l    = Deletable r (stimes n m) l
+    | l <  r    = Deletable (i*(r-l) + l) m l
+    | otherwise = Deletable r m (i*(l-r) + r)
+    where
+      i = fromIntegral n :: Int
+
 instance (Semigroup m, Monoid m) => Monoid (Deletable m) where
   mempty = Deletable 0 mempty 0
   mappend = (<>)

--- a/src/Data/Monoid/Recommend.hs
+++ b/src/Data/Monoid/Recommend.hs
@@ -58,6 +58,9 @@ instance Semigroup a => Semigroup (Recommend a) where
   Commit a    <> Recommend _ = Commit a
   Commit a    <> Commit b    = Commit (a <> b)
 
+  stimes n (Recommend m) = Recommend (stimes n m)
+  stimes n (Commit    m) = Commit    (stimes n m)
+
 instance (Semigroup a, Monoid a) => Monoid (Recommend a) where
   mappend = (<>)
   mempty  = Recommend mempty

--- a/src/Data/Monoid/Split.hs
+++ b/src/Data/Monoid/Split.hs
@@ -67,6 +67,10 @@ instance Semigroup m => Semigroup (Split m) where
   (m1  :| m2)  <> (M m2')      = m1                :| m2 <> m2'
   (m11 :| m12) <> (m21 :| m22) = m11 <> m12 <> m21 :| m22
 
+  stimes n (M m     ) = M (stimes n m)
+  stimes 1 (m       ) = m
+  stimes n (m1 :| m2) = m1 <> stimes (pred n) (m2 <> m1) :| m2
+
 instance (Semigroup m, Monoid m) => Monoid (Split m) where
   mempty  = M mempty
   mappend = (<>)


### PR DESCRIPTION
Some semigroups have fast `stimes` implementations: for instance, Map and Set are idempotent so `stimes = id` and for Sum `stimes` is just `(*)`. If we lift `stimes` to the underlying semigroup it might be `O(1)`  rather than `(<>) * log n`. Also, `Split`, `Cut` and `Deletable` have "clever" instances.

With the sole exception of `Recommend`, all of these _should_ check and throw an exception if `n<=0`, but I see no point in adding a check only to crash the program.