### PR TITLE
Revision 1: allow base-4.16 in benchmarks

### DIFF
--- a/monoid-extras.cabal
+++ b/monoid-extras.cabal
@@ -1,5 +1,6 @@
 name:                monoid-extras
 version:             0.6.1
+x-revision:          1
 synopsis:            Various extra monoid-related definitions and utilities
 description:         Various extra monoid-related definitions and utilities,
                      such as monoid actions, monoid coproducts, semi-direct
@@ -55,7 +56,7 @@ benchmark semi-direct-product
   hs-source-dirs: benchmarks
   main-is: SemiDirectProduct.hs
   type: exitcode-stdio-1.0
-  build-depends: base          >= 4.3 &&  < 4.16
+  build-depends: base          >= 4.3 &&  < 4.17
                , semigroups
                , criterion
                , monoid-extras


### PR DESCRIPTION
Revision 1: allow base-4.16 in benchmarks

Revision published at: https://hackage.haskell.org/package/monoid-extras-0.6.1/revisions/