### PR TITLE
Semigroup constraint for the class Action 

### DIFF
--- a/src/Data/Monoid/Action.hs
+++ b/src/Data/Monoid/Action.hs
@@ -57,7 +57,7 @@ import           Data.Group
 --   instance of the form @Action m SomeType@ since it will overlap
 --   with instances of the form @Action SomeMonoid t@.  Newtype
 --   wrappers can be used to (awkwardly) get around this.
-class Action m s where
+class Semigroup m => Action m s where
 
   -- | Convert a value of type @m@ to an action on @s@ values.
   act :: m -> s -> s
@@ -85,17 +85,11 @@ instance Action m s => Action (Maybe m) s where
 instance Action (Endo a) a where
   act = appEndo
 
-instance Num a => Action Integer (Sum a) where
-  n `act` a = fromInteger n <> a
+instance Num a => Action (Sum a) a where
+  a `act` n =  getSum (a <> Sum n)
 
-instance Num a => Action Integer (Product a) where
-  n `act` a = fromInteger n <> a
-
-instance Fractional a => Action Rational (Sum a) where
-  n `act` a = Sum (fromRational n) <> a
-
-instance Fractional a => Action Rational (Product a) where
-  n `act` a = Product (fromRational n) <> a
+instance Num a => Action (Product a) a where
+  a `act` n =  getProduct (a <> Product n)
 
 -- | An action of a group is "free transitive", "regular", or a "torsor"
 --   iff it is invertible.

--- a/src/Data/Monoid/MList.hs
+++ b/src/Data/Monoid/MList.hs
@@ -122,10 +122,16 @@ instance (t :>: a) => (:>:) (b ::: t) a where
 newtype SM m = SM m
                deriving Show
 
-instance (Action (SM a) l2, Action l1 l2) => Action (a, l1) l2 where
+instance Semigroup a => Semigroup (SM a) where
+  SM x <> SM y = SM (x <> y)
+
+instance Monoid a => Monoid (SM a) where
+  mempty = SM mempty
+
+instance (Semigroup a, Action (SM a) l2, Action l1 l2) => Action (a, l1) l2 where
   act (a,l) = act (SM a) . act l
 
-instance Action (SM a) () where
+instance Semigroup a => Action (SM a) () where
   act _ _ = ()
 
 instance (Action a a', Action (SM a) l) => Action (SM a) (Maybe a', l) where


### PR DESCRIPTION
I started to use monoid-extras, but one detail that stopped me : the Action class doesn't inherit of the semigroup structure of it's first argument. Is there a reason why the declaration of Action isn't 

`class Semigroup m => Action m s where `

instead of the current 

`class Action m s where`

I propose here a quick solution, which might break some code depending on Action. It seems to me that the necessary changes to the Product and Sum instances make much more sense like this , since it should be elements of the monoid Sum (or Product) that should act on their underlying set, and not the other way around.

Cheers !


