### PR TITLE
Added a new `Set` monoid

### DIFF
--- a/monoid-extras.cabal
+++ b/monoid-extras.cabal
@@ -33,6 +33,7 @@ library
                      Data.Monoid.Inf,
                      Data.Monoid.MList,
                      Data.Monoid.Recommend,
+                     Data.Monoid.Set,
                      Data.Monoid.Split,
                      Data.Monoid.WithSemigroup
 

--- a/src/Data/Monoid/Set.hs
+++ b/src/Data/Monoid/Set.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFoldable     #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DeriveTraversable  #-}
+{-# LANGUAGE MagicHash          #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+
+module Data.Monoid.Set where
+
+import Data.Data
+import Data.Semigroup
+import Data.Foldable
+import Data.Traversable
+
+import GHC.Exts (isTrue#, dataToTag#)
+import Unsafe.Coerce (unsafeCoerce)
+
+----
+
+-- | @Set@ is like @Maybe@, but the value can either be
+--   unspecified with @Unset@, or explicitly cleared with @Clear@
+data Set a
+   = Unset
+   | Set a
+   | Clear
+   deriving (Data, Typeable, Show, Read, Functor, Foldable, Traversable)
+
+
+-- | The right-hand-side or "newer" value is prefered, unless it
+--   is Unset, in which case the old value is left unchanged
+instance Semigroup (Set a) where
+
+  l <> Unset = l
+  _ <> r     = r
+
+  stimes n s
+    | n < 1 = Unset
+    | let   = s
+
+instance Monoid (Set a) where
+  mempty = Unset
+
+
+isSet :: Set a -> Bool
+isSet s = isTrue# (dataToTag# s)
+
+maybeToSet :: Maybe a -> Set a
+maybeToSet = unsafeCoerce
+
+setToMaybe :: Set a -> Maybe a
+setToMaybe (Set a) = Just a
+setToMaybe _       = Nothing
+

--- a/src/Data/Monoid/Set.hs
+++ b/src/Data/Monoid/Set.hs
@@ -33,9 +33,7 @@ instance Semigroup (Set a) where
   l <> Unset = l
   _ <> r     = r
 
-  stimes n s
-    | n < 1 = Unset
-    | let   = s
+  stimes = stimesIdempotentMonoid
 
 instance Monoid (Set a) where
   mempty = Unset


### PR DESCRIPTION
Here's a Monoid I've re-implemented a bunch of times, and I thought it might fit in here!

My use-case is when you have some sort of Config datatype:
```haskell
data Config = Config
  { foo, bar, baz :: Set Bool
  , ...
  }

unit = Config Unset Unset Unset
```

Unlike maybe, we can specify only some of the fields of our datatype and combine them with `(<>)` without inadvertently clearing all the stuff we left out
```haskell
ex0 = unit { foo = Clear }
ex1 = unit { bar = Set True }
ex2 = unit { baz = Set False }

ex3 = ex0 <> ex1 <> ex2
```

For a real world example, consider rendering in an ANSI terminal. Each "pixel" can have a bunch of styling (Bold, Blink, Underline, Foreground and background color, an actual character..). `Set` let us do the rendering in parts by composing a bunch of `Array Pixel`s together. `Clear` let us only remove- say- the background color, but leave everything else as-is, and an explicit clear means that we have to update the terminal, unlike `Unset`.

`Set a` is equivalent to `Maybe (Data.Semigroup.Last (Maybe a))`, but exactly nobody is going to use that over just re-implementing `Set` for the fifteenth time!